### PR TITLE
Fix UniverseChainId enum syntax

### DIFF
--- a/packages/uniswap/src/features/chains/types.ts
+++ b/packages/uniswap/src/features/chains/types.ts
@@ -17,7 +17,7 @@ export enum UniverseChainId {
   Blast = UniswapSDKChainId.BLAST,
   Bnb = UniswapSDKChainId.BNB,
   Celo = UniswapSDKChainId.CELO,
-  Cypherium = 16166
+  Cypherium = 16166,
   MonadTestnet = UniswapSDKChainId.MONAD_TESTNET,
   Optimism = UniswapSDKChainId.OPTIMISM,
   Polygon = UniswapSDKChainId.POLYGON,


### PR DESCRIPTION
## Summary
- add missing comma after `UniverseChainId.Cypherium`

## Testing
- `yarn workspace uniswap lint` *(fails: Error when performing the request to repo.yarnpkg.com)*
- `yarn workspace uniswap test` *(fails: Error when performing the request to repo.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_684ac824d9648330be78e91546fcf155