### PR TITLE
Update sitemap chains

### DIFF
--- a/apps/web/scripts/generate-sitemap.js
+++ b/apps/web/scripts/generate-sitemap.js
@@ -33,6 +33,7 @@ const chains = [
   'WORLDCHAIN',
   'ZKSYNC',
   'ZORA',
+  'CYPHERIUM',
 ]
 
 fs.readFile('./public/tokens-sitemap.xml', 'utf8', async (_err, data) => {


### PR DESCRIPTION
## Summary
- include CYPHERIUM when building sitemaps

## Testing
- `yarn workspace @uniswap/interface lint apps/web/scripts/generate-sitemap.js` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_684ac820e6a88330b05e92c4dc49f347