### PR TITLE
Add Cypherium trace constant

### DIFF
--- a/packages/uniswap/src/features/telemetry/constants/trace.ts
+++ b/packages/uniswap/src/features/telemetry/constants/trace.ts
@@ -227,6 +227,7 @@ export const ElementName = {
   ChainCelo: 'chain-celo',
   ChainBNB: 'chain-bnb',
   ChainAvalanche: 'chain-avalanche',
+  ChainCypherium: 'chain-cypherium',
   ChainBase: 'chain-base',
   ChainBlast: 'chain-blast',
   ChainMonadTestnet: 'chain-monad-testnet',


### PR DESCRIPTION
## Summary
- add Cypherium to telemetry trace constants

## Testing
- `yarn workspace uniswap test` *(fails: Request was cancelled)*
- `yarn g:lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684ac8220d348330849135aaede709c2