### PR TITLE
Add Cypherium network styling

### DIFF
--- a/packages/ui/src/theme/color/colors.ts
+++ b/packages/ui/src/theme/color/colors.ts
@@ -146,6 +146,10 @@ export const networkColors = {
     light: '#000000',
     dark: '#FFFFFF',
   },
+  cypherium: {
+    light: '#4B4BFF',
+    dark: '#4B4BFF',
+  },
   worldchain: {
     light: '#222222',
     dark: '#FFFFFF',
@@ -336,6 +340,7 @@ export const colorsLight = {
   chain_324: networkColors.zksync.light,
   chain_480: networkColors.worldchain.light,
   chain_1868: networkColors.soneium.light,
+  chain_16166: networkColors.cypherium.light,
 
   // Testnets
   chain_11155111: networkColors.ethereum.light,
@@ -424,6 +429,7 @@ export const colorsDark = {
   chain_324: networkColors.zksync.dark,
   chain_480: networkColors.worldchain.dark,
   chain_1868: networkColors.soneium.dark,
+  chain_16166: networkColors.cypherium.dark,
 
   // Testnets
   chain_11155111: networkColors.ethereum.dark,


### PR DESCRIPTION
## Summary
- add Cypherium network colors
- register chain 16166 in color maps

## Testing
- `yarn workspace ui lint` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684bdac2101883309d75628ae2e9a971