### PR TITLE
Limit supported chains to Cypherium

### DIFF
--- a/packages/uniswap/src/features/chains/hooks/useFeatureFlaggedChainIds.ts
+++ b/packages/uniswap/src/features/chains/hooks/useFeatureFlaggedChainIds.ts
@@ -1,23 +1,6 @@
-import { useMemo } from 'react'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
-import { filterChainIdsByFeatureFlag } from 'uniswap/src/features/chains/utils'
-import { FeatureFlags } from 'uniswap/src/features/gating/flags'
-import { useFeatureFlag } from 'uniswap/src/features/gating/hooks'
 
 // Used to feature flag chains. If a chain is not included in the object, it is considered enabled by default.
 export function useFeatureFlaggedChainIds(): UniverseChainId[] {
-  // You can use the useFeatureFlag hook here to enable/disable chains based on feature flags.
-  // Example: [ChainId.BLAST]: useFeatureFlag(FeatureFlags.BLAST)
-  // IMPORTANT: Don't forget to also update getEnabledChainIdsSaga
-  const soneiumEnabled = useFeatureFlag(FeatureFlags.Soneium)
-  const cypheriumEnabled = useFeatureFlag(FeatureFlags.Cypherium)
-
-  return useMemo(
-    () =>
-      filterChainIdsByFeatureFlag({
-        [UniverseChainId.Soneium]: soneiumEnabled,
-        [UniverseChainId.Cypherium]: cypheriumEnabled,
-      }),
-    [soneiumEnabled, cypheriumEnabled],
-  )
+  return [UniverseChainId.Cypherium]
 }

--- a/packages/uniswap/src/features/chains/types.ts
+++ b/packages/uniswap/src/features/chains/types.ts
@@ -30,32 +30,12 @@ export enum UniverseChainId {
   Zora = UniswapSDKChainId.ZORA,
 }
 
-export const SUPPORTED_CHAIN_IDS: UniverseChainId[] = [
-  UniverseChainId.Mainnet,
-  UniverseChainId.Unichain,
-  UniverseChainId.Polygon,
-  UniverseChainId.ArbitrumOne,
-  UniverseChainId.Optimism,
-  UniverseChainId.Base,
-  UniverseChainId.Bnb,
-  UniverseChainId.Cypherium,
-  UniverseChainId.Blast,
-  UniverseChainId.Avalanche,
-  UniverseChainId.Celo,
-  UniverseChainId.WorldChain,
-  UniverseChainId.Soneium,
-  UniverseChainId.Zora,
-  UniverseChainId.Zksync,
-]
+export const SUPPORTED_CHAIN_IDS: UniverseChainId[] = [UniverseChainId.Cypherium]
 
-export const SUPPORTED_TESTNET_CHAIN_IDS: UniverseChainId[] = [
-  UniverseChainId.Sepolia,
-  UniverseChainId.UnichainSepolia,
-  UniverseChainId.MonadTestnet,
-]
+export const SUPPORTED_TESTNET_CHAIN_IDS: UniverseChainId[] = []
 
 // This order is used as a fallback for chain ordering but will otherwise defer to useOrderedChainIds
-export const ALL_CHAIN_IDS: UniverseChainId[] = [...SUPPORTED_CHAIN_IDS, ...SUPPORTED_TESTNET_CHAIN_IDS]
+export const ALL_CHAIN_IDS: UniverseChainId[] = [UniverseChainId.Cypherium]
 
 export interface EnabledChainsInfo {
   chains: UniverseChainId[]


### PR DESCRIPTION
## Summary
- only use Cypherium chain constants
- remove feature flag logic in `useFeatureFlaggedChainIds`

## Testing
- `node .yarn/releases/yarn-3.2.3.cjs workspace uniswap test src/features/chains` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_685287ca502c8330a17e3345771d49ac