### PR TITLE
Suppress yarn build warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -25,6 +25,8 @@ logFilters:
     level: discard
   - code: YN0013
     level: discard
+  - code: YN0007
+    level: discard
 
 nodeLinker: node-modules
 


### PR DESCRIPTION
## Summary
- silence YN0007 warnings by adding a log filter

## Testing
- `yarn g:test` *(fails: Request was cancelled due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68529a7841848330a91e0076160b549d